### PR TITLE
feat: stream‑JSON Claude CLI with image attachment support

### DIFF
--- a/apps/api/app/services/cli/adapters/claude_code.py
+++ b/apps/api/app/services/cli/adapters/claude_code.py
@@ -1,66 +1,62 @@
-"""Claude Code provider implementation.
-
-Moved from unified_manager.py to a dedicated adapter module.
-"""
+"""Claude Code CLI adapter using stream-JSON protocol."""
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import os
+import shlex
 import tempfile
 import uuid
 from datetime import datetime
-from typing import Any, AsyncGenerator, Callable, Dict, List, Optional
+from pathlib import Path
+from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple
 
 from app.core.terminal_ui import ui
 from app.models.messages import Message
-from claude_code_sdk import ClaudeSDKClient, ClaudeCodeOptions
 
 from ..base import BaseCLI, CLIType
 
 
+def _image_to_dict(image: Any) -> Dict[str, Any]:
+    if isinstance(image, dict):
+        return image
+    data: Dict[str, Any] = {}
+    for key in ("name", "path", "base64_data", "mime_type"):
+        data[key] = getattr(image, key, None)
+    return data
+
+
+def _strip_data_url(data: str) -> str:
+    if "," in data and data.strip().startswith("data:"):
+        return data.split(",", 1)[1]
+    return data
+
+
 class ClaudeCodeCLI(BaseCLI):
-    """Claude Code Python SDK implementation"""
+    """Claude Code CLI implementation via subprocess stream JSON."""
 
     def __init__(self):
         super().__init__(CLIType.CLAUDE)
-        self.session_mapping: Dict[str, str] = {}
+        self._session_store: Dict[str, str] = {}
 
     async def check_availability(self) -> Dict[str, Any]:
-        """Check if Claude Code CLI is available"""
+        """Verify Claude CLI exists and responds."""
         try:
-            # First try to check if claude CLI is installed and working
-            result = await asyncio.create_subprocess_shell(
-                "claude -h",
+            process = await asyncio.create_subprocess_exec(
+                "claude",
+                "--version",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            stdout, stderr = await result.communicate()
-
-            if result.returncode != 0:
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                msg = stderr.decode().strip() or stdout.decode().strip()
                 return {
                     "available": False,
                     "configured": False,
-                    "error": (
-                        "Claude Code CLI not installed or not working.\n\nTo install:\n"
-                        "1. Install Claude Code: npm install -g @anthropic-ai/claude-code\n"
-                        "2. Login to Claude: claude login\n3. Try running your prompt again"
-                    ),
+                    "error": f"Claude CLI unavailable: {msg}",
                 }
-
-            # Check if help output contains expected content
-            help_output = stdout.decode() + stderr.decode()
-            if "claude" not in help_output.lower():
-                return {
-                    "available": False,
-                    "configured": False,
-                    "error": (
-                        "Claude Code CLI not responding correctly.\n\nPlease try:\n"
-                        "1. Reinstall: npm install -g @anthropic-ai/claude-code\n"
-                        "2. Login: claude login\n3. Check installation: claude -h"
-                    ),
-                }
-
             return {
                 "available": True,
                 "configured": True,
@@ -71,15 +67,20 @@ class ClaudeCodeCLI(BaseCLI):
                     "claude-opus-4-1-20250805",
                 ],
             }
-        except Exception as e:
+        except FileNotFoundError:
             return {
                 "available": False,
                 "configured": False,
                 "error": (
-                    f"Failed to check Claude Code CLI: {str(e)}\n\nTo install:\n"
-                    "1. Install Claude Code: npm install -g @anthropic-ai/claude-code\n"
-                    "2. Login to Claude: claude login"
+                    "Claude CLI not found. Install it with "
+                    "`npm install -g @anthropic-ai/claude-code` and run `claude login`."
                 ),
+            }
+        except Exception as exc:  # pragma: no cover
+            return {
+                "available": False,
+                "configured": False,
+                "error": f"Failed to check Claude CLI: {exc}",
             }
 
     async def execute_with_streaming(
@@ -92,456 +93,447 @@ class ClaudeCodeCLI(BaseCLI):
         model: Optional[str] = None,
         is_initial_prompt: bool = False,
     ) -> AsyncGenerator[Message, None]:
-        """Execute instruction using Claude Code Python SDK"""
+        """Run Claude CLI with stream-JSON interface."""
 
-        ui.info("Starting Claude SDK execution", "Claude SDK")
-        ui.debug(f"Instruction: {instruction[:100]}...", "Claude SDK")
-        ui.debug(f"Project path: {project_path}", "Claude SDK")
-        ui.debug(f"Session ID: {session_id}", "Claude SDK")
+        project_repo_path = Path(project_path).resolve()
+        if not project_repo_path.exists():
+            raise FileNotFoundError(f"Project path not found: {project_repo_path}")
 
-        if log_callback:
-            await log_callback("Starting execution...")
+        cli_model = self._get_cli_model_name(model) or "claude-sonnet-4-5-20250929"
+        ctx_instruction = self._augment_instruction(
+            instruction, project_repo_path, is_initial_prompt
+        )
 
-        # Load system prompt
+        content_blocks, attachment_meta = self._build_content_blocks(
+            ctx_instruction, images or [], project_repo_path
+        )
+
+        user_message = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": content_blocks,
+            },
+        }
+
+        settings_file = self._write_temp_settings(project_repo_path)
+        allowed_tools, disallowed_tools = self._tool_configuration(is_initial_prompt)
+
+        cmd = [
+            "claude",
+            "--print",
+            "--output-format=stream-json",
+            "--input-format=stream-json",
+            "--include-partial-messages",
+            "--verbose",
+            "--permission-mode",
+            "bypassPermissions",
+            "--model",
+            cli_model,
+        ]
+
+        if settings_file:
+            cmd.extend(["--settings", str(settings_file)])
+
+        if allowed_tools:
+            cmd.append("--allowed-tools")
+            cmd.extend(allowed_tools)
+        if disallowed_tools:
+            cmd.append("--disallowed-tools")
+            cmd.extend(disallowed_tools)
+
+        existing_session = await self.get_session_id(project_repo_path.name)
+        if existing_session and not is_initial_prompt:
+            cmd.extend(["--resume", existing_session])
+
+        ui.info("Starting Claude CLI process", "Claude CLI")
+        ui.debug(f"Executing command: {' '.join(shlex.quote(part) for part in cmd)}", "Claude CLI")
+
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(project_repo_path),
+        )
+
+        stderr_lines: List[str] = []
+        stderr_task = asyncio.create_task(
+            self._drain_stream(process.stderr, stderr_lines)
+        )
+
+        try:
+            if process.stdin is None:
+                raise RuntimeError("Claude CLI stdin unavailable")
+            payload = json.dumps(user_message) + "\n"
+            process.stdin.write(payload.encode("utf-8"))
+            await process.stdin.drain()
+            process.stdin.close()
+            ui.debug("Sent initial instruction to Claude CLI", "Claude CLI")
+        except Exception as exc:
+            process.kill()
+            raise RuntimeError(f"Failed to send message to Claude CLI: {exc}") from exc
+
+        assistant_buffer = ""
+        turn_id = None
+        result_emitted = False
+
+        try:
+            async for line in self._iter_stdout_lines(process.stdout):
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    ui.debug(f"Non-JSON output: {line}", "Claude CLI")
+                    continue
+
+                msg_type = payload.get("type")
+
+                if msg_type == "system":
+                    subtype = payload.get("subtype")
+                    session_identifier = payload.get("session_id")
+                    if session_identifier:
+                        await self.set_session_id(project_repo_path.name, session_identifier)
+                    meta = {
+                        "cli_type": self.cli_type.value,
+                        "hidden_from_ui": True,
+                        "event_type": subtype or "system",
+                        "session_id": session_identifier,
+                        "attachments": attachment_meta,
+                    }
+                    yield Message(
+                        id=str(uuid.uuid4()),
+                        project_id=str(project_repo_path),
+                        role="system",
+                        message_type="system",
+                        content=f"Claude CLI initialized (Model: {cli_model})",
+                        metadata_json=meta,
+                        session_id=session_id,
+                        created_at=datetime.utcnow(),
+                    )
+
+                elif msg_type == "stream_event":
+                    event = payload.get("event", {})
+                    event_type = event.get("type")
+                    if event_type == "content_block_delta":
+                        delta = event.get("delta", {})
+                        text = delta.get("text")
+                        if text:
+                            assistant_buffer += text
+                    elif event_type == "tool_use":
+                        summary = self._create_tool_summary(
+                            event.get("name") or "tool",
+                            event.get("input", {}),
+                        )
+                        yield Message(
+                            id=str(uuid.uuid4()),
+                            project_id=str(project_repo_path),
+                            role="assistant",
+                            message_type="tool_use",
+                            content=summary,
+                            metadata_json={
+                                "cli_type": self.cli_type.value,
+                                "tool_name": event.get("name"),
+                                "original_event": event,
+                            },
+                            session_id=session_id,
+                            created_at=datetime.utcnow(),
+                        )
+                    elif event_type == "tool_result":
+                        content = event.get("content")
+                        summary = self._create_tool_summary(
+                            event.get("name") or "tool_result",
+                            {"output": content},
+                        )
+                        yield Message(
+                            id=str(uuid.uuid4()),
+                            project_id=str(project_repo_path),
+                            role="system",
+                            message_type="tool_result",
+                            content=summary,
+                            metadata_json={
+                                "cli_type": self.cli_type.value,
+                                "hidden_from_ui": True,
+                                "original_event": event,
+                            },
+                            session_id=session_id,
+                            created_at=datetime.utcnow(),
+                        )
+                    elif event_type == "message_start":
+                        turn_id = event.get("message", {}).get("id")
+
+                elif msg_type == "assistant":
+                    message = payload.get("message", {})
+                    content = message.get("content", [])
+                    text = self._extract_text_from_blocks(content) or assistant_buffer
+                    if text:
+                        yield Message(
+                            id=str(uuid.uuid4()),
+                            project_id=str(project_repo_path),
+                            role="assistant",
+                            message_type="chat",
+                            content=text.strip(),
+                            metadata_json={
+                                "cli_type": self.cli_type.value,
+                                "turn_id": turn_id,
+                                "attachments": attachment_meta,
+                            },
+                            session_id=session_id,
+                            created_at=datetime.utcnow(),
+                        )
+                    assistant_buffer = ""
+
+                elif msg_type == "result":
+                    result_emitted = True
+                    is_error = payload.get("is_error", False)
+                    meta = {
+                        "cli_type": self.cli_type.value,
+                        "event_type": "result",
+                        "is_error": is_error,
+                        "duration_ms": payload.get("duration_ms"),
+                        "num_turns": payload.get("num_turns"),
+                        "session_id": payload.get("session_id"),
+                        "hidden_from_ui": True,
+                    }
+                    yield Message(
+                        id=str(uuid.uuid4()),
+                        project_id=str(project_repo_path),
+                        role="system",
+                        message_type="result",
+                        content=payload.get("result", ""),
+                        metadata_json=meta,
+                        session_id=session_id,
+                        created_at=datetime.utcnow(),
+                    )
+
+        finally:
+            await process.wait()
+            await stderr_task
+            if settings_file and settings_file.exists():
+                try:
+                    settings_file.unlink()
+                except Exception:
+                    pass
+
+        if process.returncode not in (0, None):
+            stderr_text = "\n".join(stderr_lines)
+            raise RuntimeError(
+                f"Claude CLI exited with code {process.returncode}: {stderr_text}"
+            )
+
+        if not result_emitted:
+            ui.warning("Claude CLI session ended without result event", "Claude CLI")
+
+    async def _iter_stdout_lines(self, stream: asyncio.StreamReader):
+        while True:
+            line = await stream.readline()
+            if not line:
+                break
+            text = line.decode(errors="ignore").strip()
+            if text:
+                yield text
+
+    async def _drain_stream(
+        self, stream: asyncio.StreamReader, bucket: List[str]
+    ) -> None:
+        try:
+            while True:
+                line = await stream.readline()
+                if not line:
+                    break
+                decoded = line.decode(errors="ignore").strip()
+                if decoded:
+                    bucket.append(decoded)
+        except Exception:
+            pass
+
+    def _augment_instruction(
+        self, instruction: str, project_repo_path: Path, is_initial_prompt: bool
+    ) -> str:
+        if not is_initial_prompt:
+            return instruction
+
+        entries = []
+        try:
+            for item in sorted(project_repo_path.iterdir()):
+                if item.name.startswith(".") and item.name not in {".env"}:
+                    continue
+                entries.append(item.name + ("/" if item.is_dir() else ""))
+                if len(entries) >= 30:
+                    break
+        except Exception as exc:
+            ui.warning(f"Failed to list project directory: {exc}", "Claude CLI")
+            return instruction
+
+        if not entries:
+            return instruction
+
+        context = (
+            "\n\n<project_structure>\n"
+            "Current files in project root:\n"
+            + "\n".join(f"- {name}" for name in entries)
+            + "\n</project_structure>"
+        )
+        return instruction + context
+
+    def _build_content_blocks(
+        self,
+        instruction: str,
+        images: List[Dict[str, Any]],
+        project_repo_path: Path,
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        blocks: List[Dict[str, Any]] = [{"type": "text", "text": instruction}]
+        attachments_meta: List[Dict[str, Any]] = []
+
+        for index, image in enumerate(images):
+            img = _image_to_dict(image)
+            name = img.get("name") or f"image_{index+1}"
+            declared_mime = img.get("mime_type")
+
+            base64_data = img.get("base64_data")
+            path_value = img.get("path")
+            raw_bytes: Optional[bytes] = None
+
+            if not base64_data and path_value:
+                file_path = Path(path_value)
+                if not file_path.is_absolute():
+                    file_path = project_repo_path / file_path
+                try:
+                    with open(file_path, "rb") as f:
+                        raw_bytes = f.read()
+                except Exception as exc:
+                    ui.warning(f"Failed to read image {path_value}: {exc}", "Claude CLI")
+                    continue
+            else:
+                if base64_data:
+                    try:
+                        raw_bytes = base64.b64decode(
+                            _strip_data_url(str(base64_data)), validate=False
+                        )
+                    except Exception as exc:
+                        ui.warning(f"Invalid base64 image {name}: {exc}", "Claude CLI")
+                        continue
+
+            if not raw_bytes:
+                ui.warning(f"Skipping image {name}: no data provided", "Claude CLI")
+                continue
+
+            mime_type = self._detect_image_mime(raw_bytes, declared_mime)
+
+            base64_clean = base64.b64encode(raw_bytes).decode("utf-8")
+
+            blocks.append(
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": mime_type,
+                        "data": base64_clean,
+                    },
+                }
+            )
+            attachments_meta.append(
+                {
+                    "name": name,
+                    "mime_type": mime_type,
+                    "size_bytes": len(raw_bytes),
+                }
+            )
+
+        return blocks, attachments_meta
+
+    def _tool_configuration(self, is_initial_prompt: bool) -> Tuple[List[str], List[str]]:
+        base_tools = [
+            "Read",
+            "Write",
+            "Edit",
+            "MultiEdit",
+            "Bash",
+            "Glob",
+            "Grep",
+            "LS",
+            "WebFetch",
+            "WebSearch",
+        ]
+        if is_initial_prompt:
+            return base_tools, ["TodoWrite"]
+        return base_tools + ["TodoWrite"], []
+
+    def _write_temp_settings(self, project_path: Path) -> Optional[Path]:
+        settings_path = project_path / ".claude" / "settings.json"
+        base_settings: Dict[str, Any] = {}
+        if settings_path.exists():
+            try:
+                base_settings = json.loads(settings_path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                ui.warning(f"Failed to load project settings: {exc}", "Claude CLI")
+
         try:
             from app.services.claude_act import get_system_prompt
 
             system_prompt = get_system_prompt()
-            ui.debug(f"System prompt loaded: {len(system_prompt)} chars", "Claude SDK")
-            full_system_prompt = system_prompt
-
-            # Windows has an 8191 character command-line limit when prompts are passed
-            # via command arguments. We'll only trim in fallback scenarios where we
-            # cannot use a temporary settings file.
-            trimmed_system_prompt = system_prompt
-            if os.name == "nt":
-                max_prompt_chars = 3000
-                if len(system_prompt) > max_prompt_chars:
-                    trimmed_prompt = system_prompt[:max_prompt_chars]
-                    last_linebreak = trimmed_prompt.rfind("\n")
-                    if last_linebreak > 0:
-                        trimmed_prompt = trimmed_prompt[:last_linebreak]
-                    ui.warning(
-                        (
-                            "System prompt exceeded Windows command length; "
-                            "using trimmed prompt fallback if temporary settings fail"
-                        ),
-                        "Claude SDK",
-                    )
-                    trimmed_system_prompt = trimmed_prompt
-        except Exception as e:
-            ui.error(f"Failed to load system prompt: {e}", "Claude SDK")
-            full_system_prompt = (
+        except Exception as exc:  # pragma: no cover
+            ui.warning(f"System prompt load failed: {exc}", "Claude CLI")
+            system_prompt = (
                 "You are Claude Code, an AI coding assistant specialized in building modern web applications."
             )
-            trimmed_system_prompt = full_system_prompt
 
-        # Get CLI-specific model name
-        cli_model = self._get_cli_model_name(model) or "claude-sonnet-4-5-20250929"
-
-        # Add project directory structure for initial prompts
-        if is_initial_prompt:
-            project_structure_info = """
-<initial_context>
-## Project Directory Structure (node_modules are already installed)
-.eslintrc.json
-.gitignore
-next.config.mjs
-next-env.d.ts
-package.json
-postcss.config.mjs
-README.md
-tailwind.config.ts
-tsconfig.json
-.env
-src/app/favicon.ico
-src/app/globals.css
-src/app/layout.tsx
-src/app/page.tsx
-public/
-node_modules/
-</initial_context>"""
-            if os.name == "nt":
-                ui.warning(
-                    "Skipping extra project structure context on Windows to avoid command length limits",
-                    "Claude SDK",
-                )
-            else:
-                instruction = instruction + project_structure_info
-                ui.info(
-                    f"Added project structure info to initial prompt", "Claude SDK"
-                )
-
-        session_settings_path = None
-        base_settings = {}
-        settings_file_path = os.path.join(project_path, ".claude", "settings.json")
-        if os.path.exists(settings_file_path):
-            try:
-                with open(settings_file_path, "r", encoding="utf-8") as settings_file:
-                    loaded_settings = json.load(settings_file)
-                    if isinstance(loaded_settings, dict):
-                        base_settings = loaded_settings
-                    else:
-                        ui.warning("Existing Claude settings file is not a JSON object; ignoring it", "Claude SDK")
-            except Exception as settings_error:
-                ui.warning(f"Failed to load existing Claude settings: {settings_error}", "Claude SDK")
-        session_settings = dict(base_settings)
-        session_settings["customSystemPrompt"] = full_system_prompt
-        try:
-            temp_settings = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False, encoding="utf-8")
-            json.dump(session_settings, temp_settings, ensure_ascii=False)
-            temp_settings.flush()
-            temp_settings.close()
-            session_settings_path = temp_settings.name
-            ui.debug(f"Wrote temporary Claude settings to {session_settings_path}", "Claude SDK")
-        except Exception as settings_write_error:
-            ui.warning(f"Failed to create temporary settings file for Claude CLI: {settings_write_error}", "Claude SDK")
-            session_settings_path = None
-
-        # Configure tools based on initial prompt status
-        if is_initial_prompt:
-            # For initial prompts: use disallowed_tools to explicitly block TodoWrite
-            allowed_tools = [
-                "Read",
-                "Write",
-                "Edit",
-                "MultiEdit",
-                "Bash",
-                "Glob",
-                "Grep",
-                "LS",
-                "WebFetch",
-                "WebSearch",
-            ]
-            disallowed_tools = ["TodoWrite"]
-
-            ui.info(
-                f"TodoWrite tool EXCLUDED via disallowed_tools (is_initial_prompt: {is_initial_prompt})",
-                "Claude SDK",
-            )
-            ui.debug(f"Allowed tools: {allowed_tools}", "Claude SDK")
-            ui.debug(f"Disallowed tools: {disallowed_tools}", "Claude SDK")
-
-            # Configure Claude Code options with disallowed_tools
-            option_kwargs = {
-                "allowed_tools": allowed_tools,
-                "disallowed_tools": disallowed_tools,
-                "permission_mode": "bypassPermissions",
-                "model": cli_model,
-                "continue_conversation": True,
-                "extra_args": {
-                    "print": None,
-                    "verbose": None,
-                },
-            }
-            if session_settings_path:
-                option_kwargs["settings"] = session_settings_path
-            else:
-                option_kwargs["system_prompt"] = trimmed_system_prompt
-            options = ClaudeCodeOptions(**option_kwargs)
-        else:
-            # For non-initial prompts: include TodoWrite in allowed tools
-            allowed_tools = [
-                "Read",
-                "Write",
-                "Edit",
-                "MultiEdit",
-                "Bash",
-                "Glob",
-                "Grep",
-                "LS",
-                "WebFetch",
-                "WebSearch",
-                "TodoWrite",
-            ]
-
-            ui.info(
-                f"TodoWrite tool INCLUDED (is_initial_prompt: {is_initial_prompt})",
-                "Claude SDK",
-            )
-            ui.debug(f"Allowed tools: {allowed_tools}", "Claude SDK")
-
-            # Configure Claude Code options without disallowed_tools
-            option_kwargs = {
-                "allowed_tools": allowed_tools,
-                "permission_mode": "bypassPermissions",
-                "model": cli_model,
-                "continue_conversation": True,
-                "extra_args": {
-                    "print": None,
-                    "verbose": None,
-                },
-            }
-            if session_settings_path:
-                option_kwargs["settings"] = session_settings_path
-            else:
-                option_kwargs["system_prompt"] = trimmed_system_prompt
-            options = ClaudeCodeOptions(**option_kwargs)
-
-        ui.info(f"Using model: {cli_model}", "Claude SDK")
-        ui.debug(f"Project path: {project_path}", "Claude SDK")
-        ui.debug(f"Instruction: {instruction[:100]}...", "Claude SDK")
+        base_settings["customSystemPrompt"] = system_prompt
 
         try:
-            # Change to project directory
-            original_cwd = os.getcwd()
-            os.chdir(project_path)
+            tmp = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8")
+            json.dump(base_settings, tmp, ensure_ascii=False)
+            tmp.flush()
+            tmp.close()
+            ui.debug(f"Wrote temp settings to {tmp.name}", "Claude CLI")
+            return Path(tmp.name)
+        except Exception as exc:  # pragma: no cover
+            ui.warning(f"Failed to create temp settings: {exc}", "Claude CLI")
+            return None
 
-            # Get project ID for session management
-            project_id = (
-                project_path.split("/")[-1] if "/" in project_path else project_path
-            )
-            existing_session_id = await self.get_session_id(project_id)
+    def _extract_text_from_blocks(self, blocks: List[Dict[str, Any]]) -> str:
+        text_parts: List[str] = []
+        for block in blocks or []:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text")
+                if isinstance(text, str):
+                    text_parts.append(text)
+        return "".join(text_parts)
 
-            # Update options with resume session if available
-            if existing_session_id:
-                options.resumeSessionId = existing_session_id
-                ui.info(f"Resuming session: {existing_session_id}", "Claude SDK")
 
-            try:
-                async with ClaudeSDKClient(options=options) as client:
-                    # Send initial query
-                    await client.query(instruction)
 
-                    # Stream responses and extract session_id
-                    claude_session_id = None
-
-                    async for message_obj in client.receive_messages():
-                        # Import SDK types for isinstance checks
-                        try:
-                            from anthropic.claude_code.types import (
-                                SystemMessage,
-                                AssistantMessage,
-                                UserMessage,
-                                ResultMessage,
-                            )
-                        except ImportError:
-                            try:
-                                from claude_code_sdk.types import (
-                                    SystemMessage,
-                                    AssistantMessage,
-                                    UserMessage,
-                                    ResultMessage,
-                                )
-                            except ImportError:
-                                # Fallback - check type name strings
-                                SystemMessage = type(None)
-                                AssistantMessage = type(None)
-                                UserMessage = type(None)
-                                ResultMessage = type(None)
-
-                        # Handle SystemMessage for session_id extraction
-                        if (
-                            isinstance(message_obj, SystemMessage)
-                            or "SystemMessage" in str(type(message_obj))
-                        ):
-                            # Extract session_id if available
-                            if (
-                                hasattr(message_obj, "session_id")
-                                and message_obj.session_id
-                            ):
-                                claude_session_id = message_obj.session_id
-                                await self.set_session_id(
-                                    project_id, claude_session_id
-                                )
-
-                            # Send init message (hidden from UI)
-                            init_message = Message(
-                                id=str(uuid.uuid4()),
-                                project_id=project_path,
-                                role="system",
-                                message_type="system",
-                                content=f"Claude Code SDK initialized (Model: {cli_model})",
-                                metadata_json={
-                                    "cli_type": self.cli_type.value,
-                                    "mode": "SDK",
-                                    "model": cli_model,
-                                    "session_id": getattr(
-                                        message_obj, "session_id", None
-                                    ),
-                                    "hidden_from_ui": True,
-                                },
-                                session_id=session_id,
-                                created_at=datetime.utcnow(),
-                            )
-                            yield init_message
-
-                        # Handle AssistantMessage (complete messages)
-                        elif (
-                            isinstance(message_obj, AssistantMessage)
-                            or "AssistantMessage" in str(type(message_obj))
-                        ):
-                            content = ""
-
-                            # Process content - AssistantMessage has content: list[ContentBlock]
-                            if hasattr(message_obj, "content") and isinstance(
-                                message_obj.content, list
-                            ):
-                                for block in message_obj.content:
-                                    # Import block types for comparison
-                                    from claude_code_sdk.types import (
-                                        TextBlock,
-                                        ToolUseBlock,
-                                        ToolResultBlock,
-                                    )
-
-                                    if isinstance(block, TextBlock):
-                                        # TextBlock has 'text' attribute
-                                        content += block.text
-                                    elif isinstance(block, ToolUseBlock):
-                                        # ToolUseBlock has 'id', 'name', 'input' attributes
-                                        tool_name = block.name
-                                        tool_input = block.input
-                                        tool_id = block.id
-                                        summary = self._create_tool_summary(
-                                            tool_name, tool_input
-                                        )
-
-                                        # Yield tool use message immediately
-                                        tool_message = Message(
-                                            id=str(uuid.uuid4()),
-                                            project_id=project_path,
-                                            role="assistant",
-                                            message_type="tool_use",
-                                            content=summary,
-                                            metadata_json={
-                                                "cli_type": self.cli_type.value,
-                                                "mode": "SDK",
-                                                "tool_name": tool_name,
-                                                "tool_input": tool_input,
-                                                "tool_id": tool_id,
-                                            },
-                                            session_id=session_id,
-                                            created_at=datetime.utcnow(),
-                                        )
-                                        # Display clean tool usage like Claude Code
-                                        tool_display = self._get_clean_tool_display(
-                                            tool_name, tool_input
-                                        )
-                                        ui.info(tool_display, "")
-                                        yield tool_message
-                                    elif isinstance(block, ToolResultBlock):
-                                        # Handle tool result blocks if needed
-                                        pass
-
-                            # Yield complete assistant text message if there's text content
-                            if content and content.strip():
-                                text_message = Message(
-                                    id=str(uuid.uuid4()),
-                                    project_id=project_path,
-                                    role="assistant",
-                                    message_type="chat",
-                                    content=content.strip(),
-                                    metadata_json={
-                                        "cli_type": self.cli_type.value,
-                                        "mode": "SDK",
-                                    },
-                                    session_id=session_id,
-                                    created_at=datetime.utcnow(),
-                                )
-                                yield text_message
-
-                        # Handle UserMessage (tool results, etc.)
-                        elif (
-                            isinstance(message_obj, UserMessage)
-                            or "UserMessage" in str(type(message_obj))
-                        ):
-                            # UserMessage has content: str according to types.py
-                            # UserMessages are typically tool results - we don't need to show them
-                            pass
-
-                        # Handle ResultMessage (final session completion)
-                        elif (
-                            isinstance(message_obj, ResultMessage)
-                            or "ResultMessage" in str(type(message_obj))
-                            or (
-                                hasattr(message_obj, "type")
-                                and getattr(message_obj, "type", None) == "result"
-                            )
-                        ):
-                            ui.success(
-                                f"Session completed in {getattr(message_obj, 'duration_ms', 0)}ms",
-                                "Claude SDK",
-                            )
-
-                            # Create internal result message (hidden from UI)
-                            result_message = Message(
-                                id=str(uuid.uuid4()),
-                                project_id=project_path,
-                                role="system",
-                                message_type="result",
-                                content=(
-                                    f"Session completed in {getattr(message_obj, 'duration_ms', 0)}ms"
-                                ),
-                                metadata_json={
-                                    "cli_type": self.cli_type.value,
-                                    "mode": "SDK",
-                                    "duration_ms": getattr(
-                                        message_obj, "duration_ms", 0
-                                    ),
-                                    "duration_api_ms": getattr(
-                                        message_obj, "duration_api_ms", 0
-                                    ),
-                                    "total_cost_usd": getattr(
-                                        message_obj, "total_cost_usd", 0
-                                    ),
-                                    "num_turns": getattr(message_obj, "num_turns", 0),
-                                    "is_error": getattr(message_obj, "is_error", False),
-                                    "subtype": getattr(message_obj, "subtype", None),
-                                    "session_id": getattr(
-                                        message_obj, "session_id", None
-                                    ),
-                                    "hidden_from_ui": True,  # Don't show to user
-                                },
-                                session_id=session_id,
-                                created_at=datetime.utcnow(),
-                            )
-                            yield result_message
-                            break
-
-                        # Handle unknown message types
-                        else:
-                            ui.debug(
-                                f"Unknown message type: {type(message_obj)}",
-                                "Claude SDK",
-                            )
-
-            finally:
-                try:
-                    if session_settings_path and os.path.exists(session_settings_path):
-                        os.remove(session_settings_path)
-                except Exception as cleanup_error:
-                    ui.debug(f"Failed to remove temporary settings file {session_settings_path}: {cleanup_error}", "Claude SDK")
-                # Restore original working directory
-                os.chdir(original_cwd)
-
-        except Exception as e:
-            ui.error(f"Exception occurred: {str(e)}", "Claude SDK")
-            if log_callback:
-                await log_callback(f"Claude SDK Exception: {str(e)}")
-            raise
+    def _detect_image_mime(self, raw_bytes: bytes, declared: Optional[str]) -> str:
+        """Infer MIME type from raw image bytes."""
+        if raw_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+            return "image/png"
+        if raw_bytes.startswith(b"\xff\xd8\xff"):
+            return "image/jpeg"
+        if raw_bytes.startswith((b"GIF87a", b"GIF89a")):
+            return "image/gif"
+        if raw_bytes.startswith(b"BM"):
+            return "image/bmp"
+        if raw_bytes[:4] == b"RIFF" and raw_bytes[8:12] == b"WEBP":
+            return "image/webp"
+        return declared or "image/png"
 
     async def get_session_id(self, project_id: str) -> Optional[str]:
-        """Get current session ID for project from database"""
-        try:
-            # Try to get from database if available (we'll need to pass db session)
-            return self.session_mapping.get(project_id)
-        except Exception as e:
-            ui.warning(f"Failed to get session ID from DB: {e}", "Claude SDK")
-            return self.session_mapping.get(project_id)
+        return self._session_store.get(project_id)
 
     async def set_session_id(self, project_id: str, session_id: str) -> None:
-        """Set session ID for project in database and memory"""
-        try:
-            # Store in memory as fallback
-            self.session_mapping[project_id] = session_id
-            ui.debug(
-                f"Session ID stored for project {project_id}", "Claude SDK"
-            )
-        except Exception as e:
-            ui.warning(f"Failed to save session ID: {e}", "Claude SDK")
-            # Fallback to memory storage
-            self.session_mapping[project_id] = session_id
+        self._session_store[project_id] = session_id
+
+    def _detect_image_mime(self, raw_bytes: bytes, declared: Optional[str]) -> str:
+        # Minimal signature detection to avoid external dependencies
+        if raw_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+            return "image/png"
+        if raw_bytes.startswith(b"\xff\xd8\xff"):
+            return "image/jpeg"
+        if raw_bytes.startswith((b"GIF87a", b"GIF89a")):
+            return "image/gif"
+        if raw_bytes.startswith(b"BM"):
+            return "image/bmp"
+        if raw_bytes[:4] == b"RIFF" and raw_bytes[8:12] == b"WEBP":
+            return "image/webp"
+        return declared or "image/png"
 
 
 __all__ = ["ClaudeCodeCLI"]


### PR DESCRIPTION
  - replace the legacy SDK adapter with a subprocess driver that speaks Claude
    --print --output-format=stream-json, so we can stream partial output/events
    and keep session IDs consistent
  - convert incoming ImageAttachments into inline base64 content blocks (path
    → bytes → base64), detect the correct MIME type from the raw data, and tag
    outgoing metadata so the UI can render thumbnails
  - preserve existing behavior (system prompt, tool config, resume) while
    improving stderr draining and stdio cleanup

  **testing**

  - python3 -m py_compile apps/api/app/services/cli/adapters/claude_code.py
  - manual smoke test: send a Claude request with a PNG attachment; the CLI now
    accepts it and replies with the image content