### PR TITLE
Stream Codex thinking events to chat UI

### DIFF
--- a/apps/api/app/services/cli/adapters/codex_cli.py
+++ b/apps/api/app/services/cli/adapters/codex_cli.py
@@ -392,6 +392,7 @@ Do not create subdirectories unless specifically requested by the user.
 
             # Message buffering
             agent_message_buffer = ""
+            thinking_streams: Dict[str, Dict[str, Any]] = {}
 
             # Send initial instruction payload via stdin (exec expects prompt on stdin)
             if process.stdin:
@@ -590,7 +591,75 @@ Do not create subdirectories unless specifically requested by the user.
                                 )
                             continue
 
-                        # Skip other item.* types (reasoning, plan, etc.) for now
+                        normalized_item_type = item_type.lower()
+                        is_thinking_item = any(
+                            token in normalized_item_type for token in ("think", "plan")
+                        )
+
+                        if is_thinking_item:
+                            item_id = (
+                                str(item_payload.get("id"))
+                                if item_payload.get("id") is not None
+                                else str(event_payload.get("item_id") or uuid.uuid4())
+                            )
+                            stream_state = thinking_streams.setdefault(
+                                item_id,
+                                {
+                                    "type": normalized_item_type,
+                                    "text": "",
+                                },
+                            )
+
+                            if msg_type in ("item.started", "item.created"):
+                                # Reset buffer on a fresh thinking block
+                                stream_state["text"] = ""
+                                thinking_streams[item_id] = stream_state
+                                continue
+
+                            text_delta = self._extract_thinking_delta(
+                                msg_type, event_payload, item_payload
+                            )
+
+                            if text_delta:
+                                stream_state["text"] += text_delta
+
+                            if msg_type == "item.completed":
+                                final_text = (
+                                    self._extract_thinking_final(item_payload)
+                                    or stream_state["text"]
+                                )
+                                thinking_streams.pop(item_id, None)
+                                flush_text = final_text
+                                is_partial = False
+                            elif text_delta:
+                                flush_text = stream_state["text"]
+                                is_partial = True
+                            else:
+                                # Nothing to show yet
+                                continue
+
+                            if flush_text:
+                                yield Message(
+                                    id=str(uuid.uuid4()),
+                                    project_id=project_path,
+                                    role="assistant",
+                                    message_type="thinking",
+                                    content=flush_text,
+                                    metadata_json={
+                                        "cli_type": self.cli_type.value,
+                                        "thinking_item_id": item_id,
+                                        "thinking_type": stream_state["type"],
+                                        "is_partial": is_partial,
+                                    },
+                                    session_id=session_id,
+                                    created_at=datetime.utcnow(),
+                                )
+
+                            if msg_type in ("item.completed", "item.failed", "item.error"):
+                                thinking_streams.pop(item_id, None)
+                            continue
+
+                        # Skip other item.* types we do not surface yet
                         continue
 
                     # Buffer agent message deltas
@@ -1053,6 +1122,44 @@ Do not create subdirectories unless specifically requested by the user.
                 )
         except Exception as e:
             ui.error(f"Failed to create AGENTS.md: {e}", "Codex")
+
+    @staticmethod
+    def _extract_text_candidate(source: Any) -> Optional[str]:
+        """Pull a string-like field from heterogeneous Codex payloads."""
+        if isinstance(source, str):
+            return source
+        if isinstance(source, dict):
+            for key in ("text", "content", "output", "message"):
+                value = source.get(key)
+                if isinstance(value, str) and value:
+                    return value
+        return None
+
+    def _extract_thinking_delta(
+        self,
+        msg_type: str,
+        event_payload: Dict[str, Any],
+        item_payload: Dict[str, Any],
+    ) -> Optional[str]:
+        """Extract incremental thinking text from an item.* event."""
+        if msg_type not in ("item.delta", "item.updated", "item.message.delta"):
+            # Some Codex builds emit agent_message_delta instead; guard accordingly.
+            return self._extract_text_candidate(item_payload.get("delta")) or self._extract_text_candidate(
+                event_payload.get("delta")
+            )
+        delta = (
+            self._extract_text_candidate(item_payload.get("delta"))
+            or self._extract_text_candidate(event_payload.get("delta"))
+        )
+        return delta
+
+    def _extract_thinking_final(self, item_payload: Dict[str, Any]) -> Optional[str]:
+        """Extract the final thinking text once Codex completes an item."""
+        for key in ("text", "output", "content", "result"):
+            value = item_payload.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return None
 
     async def _set_codex_approval_policy(self, process, session_id: str):
         """Set Codex approval policy to never (full-auto mode)"""

--- a/apps/web/components/ChatLog.tsx
+++ b/apps/web/components/ChatLog.tsx
@@ -107,7 +107,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 interface ChatMessage {
   id: string;
   role: 'user' | 'assistant' | 'system' | 'tool';
-  message_type?: 'chat' | 'tool_result' | 'system' | 'error' | 'info';
+  message_type?: 'chat' | 'tool_result' | 'system' | 'error' | 'info' | 'thinking';
   content: string;
   metadata_json?: any;
   parent_message_id?: string;

--- a/apps/web/components/chat/MessageList.tsx
+++ b/apps/web/components/chat/MessageList.tsx
@@ -64,6 +64,16 @@ export function MessageList({ messages, isLoading }: MessageListProps) {
         {messageGroups.map((group, groupIndex) => {
           const firstMessage = group[0];
           const isUser = firstMessage.role === 'user';
+          const thinkingMessages = group.filter(message => message.message_type === 'thinking');
+          const latestThinkingMap = new Map<string, string>();
+          thinkingMessages.forEach(message => {
+            const itemId = message.metadata_json?.thinking_item_id || message.id;
+            latestThinkingMap.set(itemId, message.content);
+          });
+          const aggregatedThinkingContent = Array.from(latestThinkingMap.values())
+            .map(content => content.trim())
+            .filter(Boolean)
+            .join('\n\n');
           
           return (
             <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`} key={`group-${groupIndex}-${firstMessage.id}`}>
@@ -83,10 +93,20 @@ export function MessageList({ messages, isLoading }: MessageListProps) {
                 }`}
               >
                 {group.map((message, messageIndex) => {
+                  if (message.message_type === 'thinking') {
+                    return null;
+                  }
                   // Check if this message has thinking data
-                  const hasThinking = message.metadata_json?.thinking_content || message.metadata_json?.thinking_duration;
+                  const hasGeneratedThinking = Boolean(aggregatedThinkingContent);
+                  const fallbackThinkingContent = message.metadata_json?.thinking_content;
+                  const hasThinking =
+                    (!isUser && messageIndex === 0 && hasGeneratedThinking) ||
+                    Boolean(fallbackThinkingContent);
                   const thinkingDuration = message.metadata_json?.thinking_duration || 10; // Default to 10 seconds
-                  const thinkingContent = message.metadata_json?.thinking_content || "Processing request...";
+                  const thinkingContent =
+                    aggregatedThinkingContent ||
+                    fallbackThinkingContent ||
+                    "Processing request...";
                   const isThoughtExpanded = expandedThoughts.has(message.id);
                   
                   return (

--- a/apps/web/types/chat.ts
+++ b/apps/web/types/chat.ts
@@ -5,7 +5,7 @@
 export interface Message {
   id: string;
   role: 'user' | 'assistant' | 'system';
-  message_type?: 'chat' | 'error' | 'info' | 'tool_use';
+  message_type?: 'chat' | 'error' | 'info' | 'tool_use' | 'tool_result' | 'thinking';
   content: string;
   metadata_json?: Record<string, any>;
   parent_message_id?: string;


### PR DESCRIPTION
## Summary
- surface Codex item.thinking and plan events as assistant thinking messages
- add adapter helpers to accumulate deltas and emit metadata for reasoning blocks
- update chat UI/types to aggregate thinking updates into the existing thought toggle

## Testing
- npm run build --workspace apps/web
