### PR TITLE
Add support for Claude Haiku 4.5 model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,12 @@ PREVIEW_PORT_START=3100
 PREVIEW_PORT_END=3999
 
 # Claude Model Configuration
+# Available models:
+# - claude-sonnet-4-5-20250929 (default)
+# - claude-opus-4-1-20250805
+# - claude-haiku-4-5-20251001 (fast, cost-effective)
+# - claude-opus-4-20250514
+# - claude-3-5-haiku-20241022
 CLAUDE_CODE_MODEL=claude-sonnet-4-20250514
 
 # Frontend API Endpoints (automatically configured by Makefile)

--- a/apps/api/app/services/cli/adapters/claude_code.py
+++ b/apps/api/app/services/cli/adapters/claude_code.py
@@ -65,6 +65,7 @@ class ClaudeCodeCLI(BaseCLI):
                 "default_models": [
                     "claude-sonnet-4-5-20250929",
                     "claude-opus-4-1-20250805",
+                    "claude-haiku-4-5-20251001",
                 ],
             }
         except FileNotFoundError:

--- a/apps/api/app/services/cli/base.py
+++ b/apps/api/app/services/cli/base.py
@@ -51,16 +51,19 @@ MODEL_MAPPING: Dict[str, Dict[str, str]] = {
         "opus-4.1": "claude-opus-4-1-20250805",
         "sonnet-4.5": "claude-sonnet-4-5-20250929",
         "opus-4": "claude-opus-4-20250514",
+        "haiku-4.5": "claude-haiku-4-5-20251001",
         "haiku-3.5": "claude-3-5-haiku-20241022",
         # Handle claude-prefixed model names
         "claude-sonnet-4.5": "claude-sonnet-4-5-20250929",
         "claude-opus-4.1": "claude-opus-4-1-20250805",
         "claude-opus-4": "claude-opus-4-20250514",
+        "claude-haiku-4.5": "claude-haiku-4-5-20251001",
         "claude-haiku-3.5": "claude-3-5-haiku-20241022",
         # Support direct full model names
         "claude-opus-4-1-20250805": "claude-opus-4-1-20250805",
         "claude-sonnet-4-5-20250929": "claude-sonnet-4-5-20250929",
         "claude-opus-4-20250514": "claude-opus-4-20250514",
+        "claude-haiku-4-5-20251001": "claude-haiku-4-5-20251001",
         "claude-3-5-haiku-20241022": "claude-3-5-haiku-20241022",
     },
     "cursor": {

--- a/apps/web/app/[project_id]/chat/page.tsx
+++ b/apps/web/app/[project_id]/chat/page.tsx
@@ -42,6 +42,7 @@ const MODEL_FALLBACKS: Record<string, { id: string; name: string; aliases?: stri
     { id: 'claude-sonnet-4.5', name: 'Claude Sonnet 4.5', aliases: ['claude-sonnet-4-5-20250929', 'sonnet-4.5'] },
     { id: 'claude-opus-4.1', name: 'Claude Opus 4.1', aliases: ['claude-opus-4-1-20250805', 'opus-4.1'] },
     { id: 'claude-opus-4', name: 'Claude Opus 4', aliases: ['claude-opus-4-20250514', 'opus-4'] },
+    { id: 'claude-haiku-4.5', name: 'Claude Haiku 4.5', aliases: ['claude-haiku-4-5-20251001', 'haiku-4.5'] },
     { id: 'claude-haiku-3.5', name: 'Claude Haiku 3.5', aliases: ['claude-3-5-haiku-20241022', 'haiku-3.5'] }
   ],
   cursor: [

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -62,7 +62,8 @@ export default function HomePage() {
   const modelsByAssistant = {
     claude: [
       { id: 'claude-sonnet-4.5', name: 'Claude Sonnet 4.5' },
-      { id: 'claude-opus-4.1', name: 'Claude Opus 4.1' }
+      { id: 'claude-opus-4.1', name: 'Claude Opus 4.1' },
+      { id: 'claude-haiku-4.5', name: 'Claude Haiku 4.5' }
     ],
     cursor: [
       { id: 'gpt-5', name: 'GPT-5' },

--- a/apps/web/components/CreateProjectModal.tsx
+++ b/apps/web/components/CreateProjectModal.tsx
@@ -32,6 +32,7 @@ const CLI_OPTIONS: CLIOption[] = [
     models: [
       { id: 'claude-sonnet-4.5', name: 'Claude Sonnet 4.5', description: 'Superior coding with 1M context window', supportsImages: true },
       { id: 'claude-opus-4.1', name: 'Claude Opus 4.1', description: 'Most intelligent model for complex coding tasks', supportsImages: true },
+      { id: 'claude-haiku-4.5', name: 'Claude Haiku 4.5', description: 'Fast and cost-effective with Sonnet-level coding', supportsImages: true },
     ],
     features: ['Advanced reasoning', 'Code generation', '1M context window']
   },

--- a/apps/web/components/GlobalSettings.tsx
+++ b/apps/web/components/GlobalSettings.tsx
@@ -42,6 +42,7 @@ const CLI_OPTIONS: CLIOption[] = [
     models: [
       { id: 'claude-sonnet-4.5', name: 'Claude Sonnet 4.5' },
       { id: 'claude-opus-4.1', name: 'Claude Opus 4.1' },
+      { id: 'claude-haiku-4.5', name: 'Claude Haiku 4.5' },
     ]
   },
   {

--- a/apps/web/components/ProjectSettings.tsx
+++ b/apps/web/components/ProjectSettings.tsx
@@ -32,6 +32,7 @@ const CLI_OPTIONS: CLIOption[] = [
     models: [
       { id: 'claude-opus-4.1', name: 'Claude Opus 4.1', description: 'Most intelligent model for complex coding tasks' },
       { id: 'claude-sonnet-4.5', name: 'Claude Sonnet 4.5', description: 'Superior coding with 1M context window' },
+      { id: 'claude-haiku-4.5', name: 'Claude Haiku 4.5', description: 'Fast and cost-effective with Sonnet-level coding' },
     ],
     features: ['Advanced reasoning', 'Code generation', '1M context window']
   },

--- a/apps/web/types/cli.ts
+++ b/apps/web/types/cli.ts
@@ -44,6 +44,7 @@ export const CLI_OPTIONS: CLIOption[] = [
     models: [
       { id: 'claude-sonnet-4.5', name: 'Claude Sonnet 4.5' },
       { id: 'claude-opus-4.1', name: 'Claude Opus 4.1' },
+      { id: 'claude-haiku-4.5', name: 'Claude Haiku 4.5' },
       { id: 'claude-3.5-sonnet', name: 'Claude 3.5 Sonnet' },
       { id: 'claude-3-opus', name: 'Claude 3 Opus' },
       { id: 'claude-3-haiku', name: 'Claude 3 Haiku' }


### PR DESCRIPTION
## What Changed
Added comprehensive support for Claude Haiku 4.5 (claude-haiku-4-5-20251001) across **all 9 model definition locations** in the codebase.

## Why
Claude Haiku 4.5 was released on October 15, 2025, and offers Sonnet-4-level coding performance at 1/3 the cost and 2x the speed. This makes it an ideal choice for cost-effective development workflows while maintaining high code quality.

## Root Cause Issue Resolved
The codebase had model definitions duplicated in **6 different frontend files** instead of using a single source of truth. Initial commit only updated 2/6 locations, causing Haiku 4.5 to not appear in most of the UI. This has been fixed.

## Changes Made

### Frontend Updates (6 files)
- **`apps/web/types/cli.ts`**: Added Haiku 4.5 to Claude model list
- **`apps/web/components/GlobalSettings.tsx`**: Added to settings UI model options
- **`apps/web/components/CreateProjectModal.tsx`**: Added to project creation modal
- **`apps/web/components/ProjectSettings.tsx`**: Added to project settings panel
- **`apps/web/app/page.tsx`**: Added to home page model selector
- **`apps/web/app/[project_id]/chat/page.tsx`**: Added to MODEL_FALLBACKS for chat display

### Backend Updates (2 files)
- **`apps/api/app/services/cli/base.py`**: Added model mappings for:
  - `haiku-4.5` → `claude-haiku-4-5-20251001`
  - `claude-haiku-4.5` → `claude-haiku-4-5-20251001`
  - `claude-haiku-4-5-20251001` → `claude-haiku-4-5-20251001` (direct support)
- **`apps/api/app/services/cli/adapters/claude_code.py`**: Added Haiku 4.5 to default models list

### Documentation
- **`.env.example`**: Added comprehensive documentation of available Claude models including Haiku 4.5

## Verification
- [x] `npm run build --workspace apps/web` passes successfully
- [x] Frontend model configuration includes Haiku 4.5 in **all 6 duplicate locations**
- [x] Backend model mappings support all naming variations
- [x] Model is available in Claude Code adapter default models
- [x] Documentation updated with model information
- [x] Haiku 4.5 now appears in all UI dropdowns and selectors

## Haiku 4.5 Details
- **Model ID**: `claude-haiku-4-5-20251001`
- **Pricing**: $1/$5 per million input/output tokens
- **Performance**: Sonnet-4-level coding performance
- **Speed**: 2x faster than Sonnet
- **Cost**: 1/3 the price of Sonnet
- **Released**: October 15, 2025

## Related Issues
None - proactive feature addition to support latest Claude model

## Breaking Changes
None - purely additive feature

## Migration Steps
None required - model is automatically available once changes are deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)