### PR TITLE
Add 'Open in New Tab' button for preview server

### DIFF
--- a/apps/web/app/[project_id]/chat/page.tsx
+++ b/apps/web/app/[project_id]/chat/page.tsx
@@ -4,7 +4,7 @@ import { AnimatePresence } from 'framer-motion';
 import { MotionDiv, MotionH3, MotionP, MotionButton } from '../../../lib/motion';
 import { useRouter, useSearchParams } from 'next/navigation';
 import dynamic from 'next/dynamic';
-import { FaCode, FaDesktop, FaMobileAlt, FaPlay, FaStop, FaSync, FaCog, FaRocket, FaFolder, FaFolderOpen, FaFile, FaFileCode, FaCss3Alt, FaHtml5, FaJs, FaReact, FaPython, FaDocker, FaGitAlt, FaMarkdown, FaDatabase, FaPhp, FaJava, FaRust, FaVuejs, FaLock, FaHome, FaChevronUp, FaChevronRight, FaChevronDown, FaArrowLeft, FaArrowRight, FaRedo } from 'react-icons/fa';
+import { FaCode, FaDesktop, FaMobileAlt, FaPlay, FaStop, FaSync, FaCog, FaRocket, FaFolder, FaFolderOpen, FaFile, FaFileCode, FaCss3Alt, FaHtml5, FaJs, FaReact, FaPython, FaDocker, FaGitAlt, FaMarkdown, FaDatabase, FaPhp, FaJava, FaRust, FaVuejs, FaLock, FaHome, FaChevronUp, FaChevronRight, FaChevronDown, FaArrowLeft, FaArrowRight, FaRedo, FaExternalLinkAlt } from 'react-icons/fa';
 import { SiTypescript, SiGo, SiRuby, SiSvelte, SiJson, SiYaml, SiCplusplus } from 'react-icons/si';
 import { VscJson } from 'react-icons/vsc';
 import ChatLog from '../../../components/ChatLog';
@@ -1964,7 +1964,7 @@ export default function ChatPage({ params }: Params) {
                       
                       {/* Action Buttons Group */}
                       <div className="flex items-center gap-1.5">
-                        <button 
+                        <button
                           className="h-9 w-9 flex items-center justify-center bg-gray-100 dark:bg-gray-900 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-200 dark:hover:bg-gray-800 rounded-lg transition-colors"
                           onClick={() => {
                             const iframe = document.querySelector('iframe');
@@ -1976,7 +1976,20 @@ export default function ChatPage({ params }: Params) {
                         >
                           <FaRedo size={14} />
                         </button>
-                        
+
+                        {/* Open in New Tab Button */}
+                        <button
+                          className="h-9 w-9 flex items-center justify-center bg-gray-100 dark:bg-gray-900 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-200 dark:hover:bg-gray-800 rounded-lg transition-colors"
+                          onClick={() => {
+                            if (previewUrl) {
+                              window.open(previewUrl, '_blank');
+                            }
+                          }}
+                          title="Open preview in new tab"
+                        >
+                          <FaExternalLinkAlt size={14} />
+                        </button>
+
                         {/* Device Mode Toggle */}
                         <div className="h-9 flex items-center gap-1 bg-gray-100 dark:bg-gray-900 rounded-lg px-1 border border-gray-200 dark:border-gray-700">
                           <button


### PR DESCRIPTION
## Summary
Added a button to open the preview server in a new browser tab, allowing users to view their application outside the iframe for better testing and development experience.

## Feature Overview
When a project's preview server is running, users can now click a button to open the preview in a new browser tab.

## Changes Made

### Frontend
**File:** `apps/web/app/[project_id]/chat/page.tsx`

1. **Icon Import** (Line 7)
   - Added `FaExternalLinkAlt` icon from react-icons/fa

2. **New Button** (Lines 1980-1991)
   - Positioned after refresh button, before device mode toggle
   - Opens `previewUrl` in new tab via `window.open(previewUrl, '_blank')`
   - Matches existing button styling for consistency
   - Tooltip: "Open preview in new tab"

## Button Layout (left to right)
```
[Address Bar] [Refresh] [Open in Tab] ← NEW  [Desktop/Mobile Toggle]
```

## UX Benefits

Users can now:
- ✅ Test app in full browser environment (not constrained by iframe)
- ✅ Use browser DevTools on preview
- ✅ Share preview URL easily
- ✅ Work with preview in multiple windows/monitors
- ✅ Test responsive design in actual browser
- ✅ Debug without iframe limitations

## Technical Details

**Implementation:**
```tsx
<button
  onClick={() => {
    if (previewUrl) {
      window.open(previewUrl, '_blank');
    }
  }}
  title="Open preview in new tab"
>
  <FaExternalLinkAlt size={14} />
</button>
```

**Preview URL Source:**
- Comes from project state: `previewUrl` (e.g., `http://localhost:3101`)
- Dynamically assigned when preview server starts
- Stored in database and fetched on page load

## Testing

**To test:**
1. Open a project in Jetable
2. Wait for preview server to start (or click play button)
3. Look for new external link icon in preview toolbar
4. Click it - preview should open in new tab at correct port

**Verified:**
- ✅ Button appears when preview is running
- ✅ Button uses correct preview URL
- ✅ Styling matches existing buttons
- ✅ Tooltip shows on hover
- ✅ Opens in new tab (not same tab)

## Screenshots

**Button location in toolbar:**
```
┌────────────────────────────────────────────────┐
│ [← →] [🔄] [🔗] [💻][📱]                        │
│        ↑    ↑                                   │
│    Refresh  New!                                │
└────────────────────────────────────────────────┘
```

## Files Changed
- `apps/web/app/[project_id]/chat/page.tsx` (+16, -3)

**Total:** 1 file, 13 lines changed

## Breaking Changes
None - this is purely additive functionality

## Related Issues
Addresses user request for easier access to preview server in separate browser tab

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Jet Sanchez <jetsanchezzz@gmail.com>