### PR TITLE
Fix Codex CLI plan tool flag

### DIFF
--- a/apps/api/app/services/cli/adapters/codex_cli.py
+++ b/apps/api/app/services/cli/adapters/codex_cli.py
@@ -380,6 +380,8 @@ Do not create subdirectories unless specifically requested by the user.
             "Codex",
         )
 
+        event_timeout = int(os.getenv("CLAUDABLE_CODEX_EVENT_TIMEOUT", "90"))
+
         try:
             # Start Codex process
             process = await asyncio.create_subprocess_exec(
@@ -502,7 +504,27 @@ Do not create subdirectories unless specifically requested by the user.
                 return
 
             # Process streaming events
-            async for line in process.stdout:
+            while True:
+                try:
+                    line = await asyncio.wait_for(
+                        process.stdout.readline(), timeout=event_timeout
+                    )
+                except asyncio.TimeoutError:
+                    ui.error(
+                        f"No Codex events received for {event_timeout}s; terminating session",
+                        "Codex",
+                    )
+                    try:
+                        process.kill()
+                    except Exception:
+                        pass
+                    raise RuntimeError(
+                        f"Codex produced no streaming events for {event_timeout} seconds"
+                    )
+
+                if not line:
+                    break
+
                 line_str = line.decode().strip()
                 if not line_str:
                     continue
@@ -514,6 +536,14 @@ Do not create subdirectories unless specifically requested by the user.
                         continue
                     msg_type = event_payload.get("type")
                     if not msg_type:
+                        continue
+
+                    if msg_type == "codex/event/raw_response_item":
+                        raw_messages = self._convert_raw_response_item(
+                            event_payload, project_path, session_id
+                        )
+                        for raw_message in raw_messages:
+                            yield raw_message
                         continue
 
                     if msg_type in [
@@ -1173,6 +1203,58 @@ Do not create subdirectories unless specifically requested by the user.
             if isinstance(value, str) and value:
                 return value
         return None
+
+    def _convert_raw_response_item(
+        self, payload: Dict[str, Any], project_path: str, session_id: Optional[str]
+    ) -> List[Message]:
+        messages: List[Message] = []
+        if not isinstance(payload, dict):
+            return messages
+
+        response_item = payload.get("msg") or payload.get("item") or payload
+        if not isinstance(response_item, dict):
+            return messages
+
+        if response_item.get("type") != "message":
+            return messages
+
+        role = str(response_item.get("role", "assistant")).lower()
+        content_items = response_item.get("content") or []
+        text_parts: List[str] = []
+
+        if isinstance(content_items, list):
+            for item in content_items:
+                if isinstance(item, dict):
+                    text_value = item.get("text")
+                    if isinstance(text_value, str) and text_value.strip():
+                        text_parts.append(text_value.strip())
+
+        if not text_parts:
+            return messages
+
+        content_text = "\n".join(text_parts).strip()
+        if not content_text:
+            return messages
+
+        mapped_role = role if role in ("assistant", "user", "system") else "assistant"
+        metadata = {
+            "cli_type": self.cli_type.value,
+            "raw_response_item": response_item,
+        }
+
+        messages.append(
+            Message(
+                id=str(uuid.uuid4()),
+                project_id=project_path,
+                role=mapped_role,
+                message_type="chat" if mapped_role != "system" else "system",
+                content=content_text,
+                metadata_json=metadata,
+                session_id=session_id,
+                created_at=datetime.utcnow(),
+            )
+        )
+        return messages
 
     async def _set_codex_approval_policy(self, process, session_id: str):
         """Set Codex approval policy to never (full-auto mode)"""


### PR DESCRIPTION
## What Changed
- replace the removed `--include-plan-tool` flag with the supported `--enable plan_tool` when spawning Codex CLI
- log Codex stderr whenever session initialization fails so CLI argument errors surface in Jetable logs

## Why
Codex CLI 0.49.0 removed `--include-plan-tool`; the adapter was passing it anyway, so Codex aborted with "unexpected argument" and we reported "Failed to initialize Codex session". Switching to `--enable plan_tool` and surfacing stderr brings Codex back.

## Verification
- manual: invoked Codex CLI with the new flags; Jetable Codex agent now responds and errors surface in logs.